### PR TITLE
Feature/newrelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'js-routes'
 # Rollbar-gem is the SDK for Ruby apps and includes support for apps using Rails, Sinatra, Rack, plain Ruby, and other frameworks.
 # Github source code: https://github.com/rollbar/rollbar-gem
 gem 'rollbar'
+# The New Relic Ruby agent monitors your applications to help you identify and solve performance issues. 
+# Github source code: https://github.com/newrelic/newrelic-ruby-agent
+gem 'newrelic_rpm'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.5.6)
+    newrelic_rpm (8.13.1)
     nio4r (2.5.8)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
@@ -328,6 +329,7 @@ DEPENDENCIES
   js-routes
   kaminari
   listen (~> 3.3)
+  newrelic_rpm
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -1,0 +1,65 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated November 22, 2022
+#
+# This configuration file is custom generated for NewRelic Administration
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: ENV['NEWRELIC_LICENSE_KEY']
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: Taskmanager
+
+  distributed_tracing:
+    enabled: true
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+  application_logging:
+    # If `true`, all logging-related features for the agent can be enabled or disabled
+    # independently. If `false`, all logging-related features are disabled.
+    enabled: true
+    forwarding:
+      # If `true`, the agent captures log records emitted by this application.
+      enabled: true
+      # Defines the maximum number of log records to buffer in memory at a time.
+      max_samples_stored: 10000
+    metrics:
+      # If `true`, the agent captures metrics related to logging for this application.
+      enabled: true
+    local_decorating:
+      # If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+      # This requires a log forwarder to send your log files to New Relic.
+      # This should not be used when forwarding is enabled.
+      enabled: false
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: Taskmanager (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: Taskmanager (Staging)
+
+production:
+  <<: *default_settings

--- a/render.yaml
+++ b/render.yaml
@@ -21,3 +21,5 @@ services:
         sync: false
       - key: ROLLBAR_RAILS_ACCESS_TOKEN
         sync: false
+      - key: NEWRELIC_LICENSE_KEY
+        sync: false


### PR DESCRIPTION
# Completed task Newrelic integration

[Add Newrelic monitoring on production server](https://learn.dualboot.ru/courses/5/lessons/77/practices/1163)

<img width="858" alt="Снимок экрана 2022-11-22 в 22 01 08" src="https://user-images.githubusercontent.com/912530/203388352-9a6a1289-69f5-43b7-a2e7-03e65aaa9ab3.png">

**Вопрос на засыпку.**

В инструкции пишут, что нужно будет прокинуть в host сбор метрик по логам и инфраструкте  после деплоя.

Предлагают два актуальных варианта:

1. Используя `docker run`:
```bash
docker run \
-d \
--name newrelic-infra \
--network=host \
--cap-add=SYS_PTRACE \
--privileged \
--pid=host \
-v "/:/host:ro" \
-v "/var/run/docker.sock:/var/run/docker.sock" \
-e NRIA_LICENSE_KEY=eu01xx1139f4f0e8b2bdffaa2b808b2d8974NRAL \
newrelic/infrastructure:latest
```

2. Используя `curl`-запрос
```bash
curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=undefined NEW_RELIC_ACCOUNT_ID=3709137 NEW_RELIC_REGION=EU /usr/local/bin/newrelic install -n logs-integration
```

Проблема в том, что доступа к серверу у меня нет (free plan limit). Придется после того, дополнительно делать коммит и пробовать прокинуть одну из этих команд в docker-compose CMD с условием, что это продакшн окружение.. Есть еще вариант отдельным коммитом это сделать через [Deploy Hook](https://render.com/docs/deploy-hooks).
Или есть какой-то более элегантный способ, чтобы и историю коммитов не засирать и выполнить необходимые условия установки Newrelic?

Не могу с ходу сообразить. Куда можно еще сунуть это добро, чтобы разово выполнить или же действительно стоит  при каждом билде повторять эту операцию.. Build script внутри контейнера выполняется. Docker-compose как-будто единственный вариант, но тоже не сработает, потому что нужно снаружи контейнера выполнить этот скрипт.